### PR TITLE
Fix docs: Wrong format json in command "list" results

### DIFF
--- a/docs/usage/commands.md
+++ b/docs/usage/commands.md
@@ -120,7 +120,7 @@ List the existing module deployments and the module deployments to create, updat
             }
         ]
     },
-    "NoChanges": {
+    "NoChanges": [
         {
             "Deployment": {
                 "Module": "string",
@@ -138,7 +138,7 @@ List the existing module deployments and the module deployments to create, updat
                 "LastChangedTime": "string"
             }
         }
-    }
+    ]
 }
 ```
 


### PR DESCRIPTION
Fix docs: Wrong format json in command "list" results